### PR TITLE
Add run files for streamlit app

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ We hear from so many individuals and companies about eco-friendly solutions or p
 
 from root path, run: 
 ```
-streamlit run ./ui/app.py
+(Linux or Mac users)> sh ./scripts/start-streamlit-app-linux
+(Windows users)> ./scripts/start-streamlit-app-windows.bat
 ```
 
 ### Dependencies

--- a/rip/utils.py
+++ b/rip/utils.py
@@ -4,7 +4,7 @@ from api_secrets import API_KEY, ORGANIZATION
 from typing import Dict, Any
 
 
-DEFAULT_IMG_URL = "https://github.com/Ohyeon5/RIP/blob/ohyeon5/first_ui/figs/default_img.png"
+DEFAULT_IMG_URL = "https://raw.githubusercontent.com/Ohyeon5/RIP/main/figs/default_img.png"
 
 """ for all possible parameters, see https://beta.openai.com/docs/api-reference/completions/create
 Note that `best_of` >= `n` is required 

--- a/scripts/start-streamlit-app-linux
+++ b/scripts/start-streamlit-app-linux
@@ -1,0 +1,4 @@
+#!/bin/bash
+export PYTHONPATH=$(dirname $(readlink -f $(dirname "$0")))
+
+streamlit run ./ui/app.py

--- a/scripts/start-streamlit-app-windows.bat
+++ b/scripts/start-streamlit-app-windows.bat
@@ -1,0 +1,5 @@
+set file_path=%~dp0
+echo %~dp0
+set PYTHONPATH=%PYTHONPATH%;%file_path%;
+
+streamlit run .\ui\app.py


### PR DESCRIPTION
Add run files for streamlit app, these scripts do:
- set/export pythonpath as the root directory
- run streamlit app

Windows and Linux (potentially will work in mac) versions available